### PR TITLE
Fix questions without score

### DIFF
--- a/src/js/components/student_row.coffee
+++ b/src/js/components/student_row.coffee
@@ -6,10 +6,10 @@ _          = require 'lodash'
 noSubmission = ->
   {
     answers: [
-      {score: false}
-      {score: false}
-      {score: false}
-      {score: false}
+      {}
+      {}
+      {}
+      {}
     ]
   }
 
@@ -23,13 +23,14 @@ StudentRow = React.createClass
     (tr {onClick: @doClick, className: "student_row selectable"},
       (th {className: "team_name"}, data.student),
       for a, idx in lastSubmission.answers
-      #_.map lastSubmission.answers, (a) ->
-        if a.score != false
+        if a.answer?
           className = "marker complete"
-          className += " " + "score_#{a.score}"
-          score = (span {className: "score_#{a.score}"}, a.score)
         else
           className = "marker incomplete"
+        if a.score?
+          className += " score_#{a.score}"
+          score = (span {className: "score_#{a.score}"}, a.score)
+        else
           score = (span {}, "")
         (td {key: data.key + idx},
           (div {className: className}, score)

--- a/src/js/data/runs.coffee
+++ b/src/js/data/runs.coffee
@@ -43,11 +43,11 @@ getSubmissions = (questions) ->
     answers: getAnswers(questions)
 
 getAnswers = (questions) ->
-  _.map questions, (question) ->
+  for question, idx in questions
     question_index: question.index
     answer: randomAnswer[_.random(1, 4)]()
     feedback: "feedback"
-    score: _.random(1, 5)
+    score: if idx % 2 == 0 then null else _.random(1, 5)
 
 module.exports = (students, questions) ->
   _.map students, (s) ->


### PR DESCRIPTION
Small fix, as I striped out previous logic with "completed" question (as I didn't realize that we needed it for non-c-rater questions). I've just restored it, but tried to simplify too:
- answer is completed if there is an answer text provided (so there is no "completed" prop)
- score is displayed if score is provided (!= null)

I've fixed fake data too, so now it generates answers without scores.
