### PR TITLE
Sort  students rows by updated_at sumission time.

### DIFF
--- a/src/js/components/report_overlay.coffee
+++ b/src/js/components/report_overlay.coffee
@@ -12,12 +12,23 @@ ReportOverlay = React.createClass
 
   mixins: [openable]
 
+  # List of students sorted from most recently updated to least.
+  # Those who have no submissions are at the bottom of the list.
+  sorted_students: ->
+    _.sortBy(@props.data.students, (value) ->
+      if not value.submissions
+        0
+      else
+        v = _.max(value.submissions, 'created_at')
+        v.created_at
+    ).reverse()
+
   render: ->
     (div {className: "report_overlay"},
       (div {className: @className("tab"), onClick: @props.toggle}, "Report")
       (div {className: @className("content")},
         (Report
-          students: @props.data.students
+          students: @sorted_students()
           questions: @props.questions
           hidden: @props.hideOverviewReport
           clickStudent: @props.onShowStudentDetails


### PR DESCRIPTION
Hi @pjanik   quick change.

Now we sort the student rows by who has done work most recently.  This was a request this morning from Trudi.

It used to sort this way:
![screen shot 2016-03-04 at 9 44 41 am](https://cloud.githubusercontent.com/assets/22908/13534177/e68db56a-e201-11e5-81bc-922256692d3a.png)

Now it sorts like this:
![concord-consortium_github_io_hasdashboard__offering_http___has_portal_concord_org_api_v1_offerings_4535_token_9679053f21277d7640df4a3a944c0659](https://cloud.githubusercontent.com/assets/22908/13534197/f836b046-e201-11e5-87ff-9c4cbea4aaeb.jpg)
