### PR TITLE
Make student's name clickable (opens the page the student is on)

### DIFF
--- a/src/css/toc.styl
+++ b/src/css/toc.styl
@@ -65,6 +65,7 @@
     background-size cover
     background-image url(../img/students_count_bg.png)
     position: relative
+    cursor: default
     .students-count-value
       position absolute
       top  1em
@@ -73,10 +74,8 @@
       width 100%
       height 100%
 
-
-
   .student-names
-    left: 40px
+    left: 35px
     min-width: 200px
     background-color hsla(43, 85%, 55%, 1.0);
     box-shadow 1px 1px 3px hsla(33, 34%, 0%, 0.25)
@@ -85,7 +84,9 @@
     overflow hidden
     padding 0.2em
     border-radius 4px
-    div
+    cursor: default
+    .name
+      display: block
       font-size 10pt
       line-height 1.4em
       text-align left
@@ -94,6 +95,8 @@
       margin 0.2em
       margin-left 1em
       text-wrap none
+    .name.clickable:hover
+      cursor: pointer
 
   .activity-wrap
     height: 90%;
@@ -111,3 +114,6 @@
 
   .activity.hidden > ul
     display none
+
+   .activity:hover
+     cursor: pointer

--- a/src/js/components/app.coffee
+++ b/src/js/components/app.coffee
@@ -29,7 +29,6 @@ App = React.createClass
     activityId: null
     sequenceId: null
     pageId: null
-    pageUrl: null
     studentsPortalInfo: []
     students: []
     sequence: null
@@ -91,7 +90,6 @@ App = React.createClass
       @setState
         sequence: sequence
         pageId: firstPage.id
-        pageUrl: "#{@state.laraBaseUrl}/#{firstPage.url}"
 
     resources = "activities"
     id = @state.activityId
@@ -158,28 +156,28 @@ App = React.createClass
     @setState
       nowShowing: ShowingOverview
 
-  setPage: (pageId, pageUrl) ->
+  setPage: (pageId) ->
     @setState
       pageId: pageId
-      pageUrl: "#{@state.laraBaseUrl}/#{pageUrl}"
       nowShowing: ShowingOverview
       selectedQuestion: null
       selectedStudent: null
 
+  getCurrentPage: ->
+    pages = @state.sequence?.activities.map (a) -> a.pages
+    pages = _.flatten pages
+    _.find pages, (p) => p.id == @state.pageId
+
   getQuestions: ->
     return [] unless @state.sequence
-    pages = @state.sequence.activities.map (a) -> a.pages
-    pages = _.flatten pages
-    page = (_.find pages, (p) => p.id == @state.pageId)
-
-    return [] unless page.questions
-    page.questions
-
+    @getCurrentPage().questions || []
 
   render: ->
+    page = @getCurrentPage()
+
     (div {className: "app"},
       (ActivityBackround
-        pageUrl: @state.pageUrl
+        pageUrl: if page then "#{@state.laraBaseUrl}/#{page.url}" else null
       )
       (ReportOverlay
         opened: @state.showReport

--- a/src/js/components/nav_overlay.coffee
+++ b/src/js/components/nav_overlay.coffee
@@ -20,8 +20,8 @@ Nav = React.createClass
           sequence: @props.sequence
           students: @props.students
           setPage: @props.setPage
-          activity: @state.activity
-          setActivity: (act_id) =>
+          selectedActivity: @state.activity
+          selectActivity: (act_id) =>
             if act_id is @state.activity
               @setState(activity: null)
             else


### PR DESCRIPTION
Makes student's name clickable, it opens the last page that the student was on. It's pretty much equivalent to clicking on a page link.

Also, this PR includes some tiny refactoring. I've removed `pageUrl` from state, as it's redundant and it simplifies this story. 
