### PR TITLE
New score color circles consistent with new runtime colors.

### DIFF
--- a/src/css/report.styl
+++ b/src/css/report.styl
@@ -62,37 +62,58 @@ table
     padding 1px 0 0 0
     text-align center
 
-    &.complete
-      background-color hsl(0,0,67)
-
     &.incomplete
       background-color white
       border solid 1px #aaa;
 
-  div.marker.score_-1 // test score
-    background-color hsl(16,73,56)
-    color hsl(0,0,100%)
-  div.marker.score_0
-    background-color rgb(190,34,40)
-    color hsl(0,0,100%)
-  div.marker.score_1
-    background-color rgb(190,34,40)
-    color hsl(0,0,100%)
-  div.marker.score_2
-    background-color rgb(241,87,34)
-    color hsl(0,0,100%)
-  div.marker.score_3
-    background-color rgb(250,176,23)
-    color hsl(0,0,100%)
-  div.marker.score_4
-    background-color rgb(127,194,65)
-    color hsl(0,0,100%)
-  div.marker.score_5
-    background-color rgb(26,155,72)
-    color hsl(0,0,100%)
-  div.marker.score_6
-    background-color rgb(26,155,72)
-    color hsl(0,0,100%)
+    &.complete
+      background-color hsl(0,0,67)
+      color hsl(0,0,100)
+
+      &.max_score_6
+        &.score_-1 // test score
+          background-color hsl(0,0,0)
+
+        &.score_0
+          background-color hsl(0,0,0)
+
+        &.score_1
+          background-color hsl(354,100, 33)
+
+        &.score_2
+          background-color hsl(16, 73, 56)
+
+        &.score_3
+          background-color hsl(42, 90, 55)
+
+        &.score_4
+          background-color hsl(68, 65, 50)
+
+        &.score_5
+          background-color hsl(86, 63, 55)
+
+        &.score_6
+          background-color hsl(90, 42, 46)
+
+      &.max_score_4
+        &.score_-1 // test score
+          background-color hsl(0,0,0)
+
+        &.score_0
+          background-color hsl(0,0,0)
+
+        &.score_1
+          background-color hsl(354,100, 33)
+
+        &.score_2
+          background-color hsl(42, 90, 55)
+
+        &.score_3
+          background-color hsl(86, 63, 55)
+
+        &.score_4
+          background-color hsl(90, 42, 46)
+
 
   span.tries
     background hsl(0,0,67)

--- a/src/js/components/student_row.coffee
+++ b/src/js/components/student_row.coffee
@@ -16,17 +16,20 @@ StudentRow = React.createClass
     (tr {onClick: @doClick, className: "student_row selectable"},
       (th {className: "team_name"}, student.name),
       for a, idx in lastSubmission.answers
-        if a.answer?
+        max_score = a.max_score || 6
+        score = a.score
+        answer = a.answer
+        if answer?
           className = "marker complete"
         else
           className = "marker incomplete"
-        if a.score?
-          className += " score_#{a.score}"
-          score = (span {className: "score_#{a.score}"}, a.score)
+        if score?
+          className += " score_#{score} max_score_#{max_score}"
+          scoreDiv = (span {className: "score_#{score}"}, "#{score}")
         else
-          score = (span {}, "")
+          scoreDiv = (span {}, "")
         (td {key: student.name + idx},
-          (div {className: className}, score)
+          (div {className: className}, scoreDiv)
         )
       (td {},
         if !student.submissions || student.submissions.length < 1


### PR DESCRIPTION
@pjanik  if you get a chance to have a look

Very small change. The controversial thing is the default `max_score` set to 6. It shouldn't happen and so it's too defensive, but for the mock learner data, there is no `max_score`

[#120595151]
https://www.pivotaltracker.com/story/show/120595151
