### PR TITLE
Fix TOC touch support, update React, add onTouchTap plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   "dependencies": {
     "jquery": "^2.1.4",
     "lodash": "^3.10.1",
-    "react": "^0.13.3",
-    "react-redux": "^3.1.0",
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8",
+    "react-tap-event-plugin": "^0.2.2",
     "rollbar-browser": "^1.9.1"
   }
 }

--- a/src/js/main.coffee
+++ b/src/js/main.coffee
@@ -1,13 +1,19 @@
+React = require 'react'
+ReactDOM = require 'react-dom'
+injectTapEventPlugin = require 'react-tap-event-plugin'
+injectTapEventPlugin(
+  shouldRejectClick: (lastTouchEventTimestamp, clickEventTimestamp) ->
+    return true
+)
 require './init-rollbar.coffee'
 require '../css/main.styl'
 require '../css/normalize.min.css'
 # This is a hack to watch changes in index.html too.
 require '../../public/index.html'
 $ = require './vendor/jquery.min.js'
-React = require 'react'
 
 App = React.createFactory require './components/app.coffee'
 
 $(document).ready (event) ->
   elm = $('#app')[0]
-  React.render(App({}), elm)
+  ReactDOM.render(App({}), elm)


### PR DESCRIPTION
Fixes TOC touch events. Everything works fine as long as you stick to basic onClick handlers, but `mouseEnter` and custom `onTouchEnd` were causing many problems.

I've added tap-event plugin, as touchEnd wasn't working too well e.g. when you scroll TOC.
Its readme (https://github.com/zilverline/react-tap-event-plugin) says it should handle ghost click events on mobile browsers, but well, it didn't seem to work for some reason (even their demo). I had to change config and call .preventDefault() anyway. No idea way, but it seems to work now. 

Also, I've updated React when I was playing with it. It's still not 15.1.0 as v15 was breaking layout and update to this one was seamless. It might be another chore to solve v15 issues.
