### PR TITLE
Toc click improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-tap-event-plugin": "^0.2.2",
+	"react-onclickoutside": "^5.2.0",
     "rollbar-browser": "^1.9.1"
   }
 }

--- a/src/css/students_count.styl
+++ b/src/css/students_count.styl
@@ -1,0 +1,50 @@
+.students-count-marker
+  width 2em
+  height 2em
+  margin-right .1em
+  display flex
+  align-items center
+  justify-items center
+  align-content center
+  justify-content center
+  text-align center
+
+.students-count
+  width 100%
+  height 100%
+  text-align center
+  background-size cover
+  background-image url(../img/students_count_bg.png)
+  position: relative
+  cursor: default
+  .students-count-value
+    position absolute
+    top  1em
+    font-size 1em
+    left 0px
+    width 100%
+    height 100%
+
+  .student-names
+    left: 35px
+    min-width: 200px
+    background-color hsla(43, 85%, 55%, 1.0);
+    box-shadow 1px 1px 3px hsla(33, 34%, 0%, 0.25)
+    background-image linear-gradient(to bottom, rgba(255,255,255,0.25), rgba(0,0,0,0.25))
+    position absolute
+    overflow hidden
+    padding 0.2em
+    border-radius 4px
+    cursor: default
+    .name
+      display: block
+      font-size 10pt
+      line-height 1.4em
+      text-align left
+      float none
+      color white
+      margin 0.2em
+      margin-left 1em
+      text-wrap none
+    .name.clickable:hover
+      cursor: pointer

--- a/src/css/toc.styl
+++ b/src/css/toc.styl
@@ -59,45 +59,6 @@
     font-size 14pt
     font-weight bold
 
-  .students-count
-    width 100%
-    height 100%
-    text-align center
-    background-size cover
-    background-image url(../img/students_count_bg.png)
-    position: relative
-    cursor: default
-    .students-count-value
-      position absolute
-      top  1em
-      font-size 1em
-      left 0px
-      width 100%
-      height 100%
-
-  .student-names
-    left: 35px
-    min-width: 200px
-    background-color hsla(43, 85%, 55%, 1.0);
-    box-shadow 1px 1px 3px hsla(33, 34%, 0%, 0.25)
-    background-image linear-gradient(to bottom, rgba(255,255,255,0.25), rgba(0,0,0,0.25))
-    position absolute
-    overflow hidden
-    padding 0.2em
-    border-radius 4px
-    cursor: default
-    .name
-      display: block
-      font-size 10pt
-      line-height 1.4em
-      text-align left
-      float none
-      color white
-      margin 0.2em
-      margin-left 1em
-      text-wrap none
-    .name.clickable:hover
-      cursor: pointer
 
   .activity-wrap
     height: 90%;

--- a/src/js/components/students_count.coffee
+++ b/src/js/components/students_count.coffee
@@ -1,0 +1,70 @@
+require '../../css/students_count.styl'
+_ = require 'lodash'
+React = require 'react'
+onClickOutside = require('react-onclickoutside')
+
+{div, a} = React.DOM
+
+
+
+# onClickOutside ( https://github.com/Pomax/react-onclickoutside )
+# handles closing our student list when something else is clicked..
+StudentsCount = onClickOutside React.createClass
+
+# onClickOutside without autoBind:false creates many warnings,
+# see: https://github.com/Pomax/react-onclickoutside/issues/89
+  autobind: false
+
+  getInitialState: ->
+    showToolTip: false
+
+  handleClickOutside: (e) ->
+    if(@state.showToolTip)
+      @hideToolTip(e)
+
+  toggleToolTip: (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+    # preventDefault and stopPropagation are needed for touch events.
+    # They ensure that click event isn't triggered and we don't trigger handlers of the parent elements
+    # (e.g. activity title click handler).
+    if(@state.showToolTip)
+      @hideToolTip(e)
+    else
+      @showToolTip(e)
+
+  hideToolTip: (e) ->
+    @setState
+      showToolTip: false
+
+  showToolTip: (e) ->
+    @setState
+      showToolTip: true
+
+  onNameClick: (e, studentData) ->
+    e.preventDefault()
+    e.stopPropagation()
+    {setPage} = @props
+    setPage(studentData.lastPageId) if setPage
+
+  render: ->
+    {showToolTip} = @state
+    {setPage} = @props
+    (div {className: 'students-count-marker'},
+    # Don't display 0.
+      if @props.students.length > 0
+        (div {className: 'students-count', onClick: @toggleToolTip.bind(@), onTouchTap: @toggleToolTip.bind(@)},
+          (div {className: 'students-count-value'}, @props.students.length)
+          if showToolTip
+            (div {className: 'student-names'}, _.map(@props.students, (st) =>
+              (a {
+                key: st.name,
+                className: if setPage then 'name clickable' else 'name',
+                onClick: (e) => @onNameClick(e, st),
+                onTouchTap: (e) => @onNameClick(e, st)
+              }, st.name))
+            )
+        )
+    )
+
+module.exports=StudentsCount

--- a/src/js/components/toc.coffee
+++ b/src/js/components/toc.coffee
@@ -1,6 +1,7 @@
 require '../../css/toc.styl'
 _ = require 'lodash'
 React = require 'react'
+onClickOutside = require('react-onclickoutside')
 
 {div, h3, ul, li, a} = React.DOM
 
@@ -65,7 +66,10 @@ Toc = React.createClass
       )
     )
 
-StudentsCount = React.createFactory React.createClass
+
+# onClickOutside ( https://github.com/Pomax/react-onclickoutside )
+# handles closing our student list when something else is clicked..
+StudentsCount = React.createFactory onClickOutside React.createClass
   getInitialState: ->
     showToolTip: false
 
@@ -102,7 +106,7 @@ StudentsCount = React.createFactory React.createClass
     (div {className: 'marker'},
       # Don't display 0.
       if @props.students.length > 0
-        (div {className: 'students-count', onTouchTap: @toggleToolTip, onMouseEnter: @showToolTip, onMouseLeave: @hideToolTip},
+        (div {className: 'students-count', onClick: @toggleToolTip, onTouchTap: @toggleToolTip},
           (div {className: 'students-count-value'}, @props.students.length)
           if showToolTip
             (div {className: 'student-names'}, _.map(@props.students, (st) =>

--- a/src/js/components/toc.coffee
+++ b/src/js/components/toc.coffee
@@ -28,7 +28,7 @@ Toc = React.createClass
       actSelected = selectedActivity == activity.id
       className = if actSelected then "activity" else "activity hidden"
       name = _.trunc "#{act_indx + 1}: #{activity.name}", {length: 36, ommission: " …" }
-      (div {className: className},
+      (div {className: className, key:activity.id},
         (h3 {
           onTouchTap: (e) => @handleActivityClick(e, activity.id)
           onClick: (e) => @handleActivityClick(e, activity.id),

--- a/src/js/components/toc.coffee
+++ b/src/js/components/toc.coffee
@@ -1,9 +1,9 @@
 require '../../css/toc.styl'
 _ = require 'lodash'
 React = require 'react'
-onClickOutside = require('react-onclickoutside')
 
 {div, h3, ul, li, a} = React.DOM
+StudentsCount = React.createFactory require './students_count.coffee'
 
 Toc = React.createClass
   getInitialState: ->
@@ -67,58 +67,6 @@ Toc = React.createClass
     )
 
 
-# onClickOutside ( https://github.com/Pomax/react-onclickoutside )
-# handles closing our student list when something else is clicked..
-StudentsCount = React.createFactory onClickOutside React.createClass
-  getInitialState: ->
-    showToolTip: false
-
-  toggleToolTip: (e) ->
-    if(@state.showToolTip)
-      @hideToolTip(e)
-    else
-      @showToolTip(e)
-
-  hideToolTip: (e) ->
-    # preventDefault and stopPropagation are needed for touch events.
-    # They ensure that click event isn't triggered and we don't trigger handlers of the parent elements
-    # (e.g. activity title click handler).
-    e.preventDefault()
-    e.stopPropagation()
-    @setState
-      showToolTip: false
-
-  showToolTip: (e) ->
-    e.preventDefault()
-    e.stopPropagation()
-    @setState
-      showToolTip: true
-
-  onNameClick: (e, studentData) ->
-    e.preventDefault()
-    e.stopPropagation()
-    {setPage} = @props
-    setPage(studentData.lastPageId) if setPage
-
-  render: ->
-    {showToolTip} = @state
-    {setPage} = @props
-    (div {className: 'marker'},
-      # Don't display 0.
-      if @props.students.length > 0
-        (div {className: 'students-count', onClick: @toggleToolTip, onTouchTap: @toggleToolTip},
-          (div {className: 'students-count-value'}, @props.students.length)
-          if showToolTip
-            (div {className: 'student-names'}, _.map(@props.students, (st) =>
-              (a {
-                key: st.name,
-                className: if setPage then 'name clickable' else 'name',
-                onClick: (e) => @onNameClick(e, st),
-                onTouchTap: (e) => @onNameClick(e, st)
-              }, st.name))
-            )
-        )
-    )
 
 QuestionMarker = React.createFactory React.createClass
   render: ->


### PR DESCRIPTION
This removes the rollover for the student pop-up list. It now requires a click. The behavior is now the same on touch and mouse devices. 

The TOC student popup listens for clicks outside of the component which will close it using [`react-onclickoutside`](https://github.com/Pomax/react-onclickoutside)

`stopPropagation` and `preventDefault` were moved into the toggle method.

Extracted the `StudentsCount` into its own component as it was getting big.

attn: @pjanik 
