### PR TITLE
Some small adjustments to local host regex in init-rollvar.coffee

### DIFF
--- a/src/js/init-rollbar.coffee
+++ b/src/js/init-rollbar.coffee
@@ -5,13 +5,23 @@ rollbar = require 'rollbar-browser'
 # - production code is deployed to the top-level dir
 # - branches are deployed to /branch/<branch-name> dir
 # - versions are deployed to /version/<version-num> dir
-env = 'production'
-if window.location.hostname == 'localhost'
-  env = 'local'
-else if branch = window.location.pathname.match /branch\/(.*)\//
-  env = 'branch-' + branch[1]
-else if version = window.location.pathname.match /version\/(.*)\//
-  env = 'version-' + version[1]
+
+
+host = window.location.hostname
+path = window.location.pathname
+
+# For localhost 127.0.0.* 168.192.* and *.local see http://regexr.com/3dl1e
+localRegex = /\blocalhost|\b127\.0\.0|\b192\.168|0\.0\.0\.0|\.local\b/
+
+versionString = switch
+  when branch  = path.match /branch\/(.*)\//   then 'branch-'  + branch[1]
+  when version = path.match /version\/(.*)\//  then 'version-' + version[1]
+  else null
+
+env = switch
+  when host.match localRegex then 'local'
+  when versionString then versionString
+  else 'production'
 
 config = {
   accessToken: '1be1724ac7f640a28f28d4891a94fd1a',


### PR DESCRIPTION
Pretty simple change.  

Some of my local dev machine names weren't getting detected by `init-rollbar.coffee` and @dstrawberrygirl was getting _crazy_ lots of email from rollbar.

attn: @pjanik  
