### PR TITLE
Small indentation fixes

### DIFF
--- a/src/css/students_count.styl
+++ b/src/css/students_count.styl
@@ -30,6 +30,7 @@
   .student-names
     left: 40px
     min-width: 200px
+    max-width: 450px
     background-color hsla(43, 85%, 55%, 1.0)
     box-shadow 1px 1px 3px hsla(33, 34%, 0%, 0.25)
     // background-image linear-gradient(to bottom, rgba(255,255,255,0.25), rgba(0,0,0,0.25))
@@ -47,7 +48,7 @@
       color white
       margin 0.2em
       margin-left 1em
-      text-wrap none
+      white-space nowrap
     .name.clickable:hover
       cursor pointer
     &:before

--- a/src/css/toc.styl
+++ b/src/css/toc.styl
@@ -32,6 +32,7 @@
       flex-wrap nowrap
       justify-content flex-start
       align-items center
+      margin-top 0.1em
       a
         color #459ace
         display block
@@ -39,18 +40,23 @@
         &:hover
           color hsl(187,45,20)
   .marker
-    width 2em
+    width 1.5em
     height 2em
     margin-right .1em
     display flex
     align-items center
-    justify-items center
     align-content center
     justify-content center
     text-align center
 
   .page-link
-    width: 270px;
+    width 270px
+    display flex
+    .number
+      display block
+    .name
+      display block
+      margin-left 0.5em
     &.current
       color hsl(187,45,20)
       font-weight bold

--- a/src/js/components/toc.coffee
+++ b/src/js/components/toc.coffee
@@ -53,7 +53,7 @@ Toc = React.createClass
                 url: p.url
                 current: p.id == currentPageId
                 hasQuestions: p.questions.length > 0
-                name: "#{indx + 1}. #{p.name}"
+                name: p.name
                 index: indx + 1
                 setPage: @setPage
               )
@@ -84,7 +84,10 @@ PageLink = React.createFactory React.createClass
   render: ->
     className = "page-link"
     className += " current" if @props.current
-    (a {href: @props.url, onClick: @onClick, onTouchTap: @onClick, className: className}, @props.name or "Page #{@props.index}")
+    (a {href: @props.url, onClick: @onClick, onTouchTap: @onClick, className: className},
+      (div {className: 'number'},"#{@props.index}.")
+      (div {className: 'name'}, @props.name or "Page #{@props.index}")
+    )
 
 getPageStudents = (students) ->
   _.reduce students, (result, s) ->

--- a/src/js/data/fake_activity.coffee
+++ b/src/js/data/fake_activity.coffee
@@ -1,4 +1,5 @@
 _ = require 'lodash'
+randomText = require './random_text.coffee'
 
 pageCounter     = 1
 activityCounter = 1
@@ -31,14 +32,18 @@ addQuestions = ->
 
 addPage = (activityId) ->
   pageId = pageCounter++
-  "name": "Page #{pageId}",
+  name = "Page #{pageId}"
+  name = if _.random(0,4) == 0 then randomText(name, 10) else name
+  "name": name,
   "id": pageId,
   "url": "/activities/#{activityId}/pages/#{pageId}",
   "questions": if Math.random() > 0.6 then addQuestions() else []
 
 module.exports = () ->
   activityId = activityCounter++
-  "name": "Fake activity #{activityId}",
+  name = "Fake activity #{activityId}"
+  name = if _.random(0,4) == 0 then randomText("activity ", 10) else name
+  "name": name,
   "url": "/activities/#{activityId}",
   "id": activityId,
   "pages": randDo(8, -> addPage(activityId))

--- a/src/js/data/fake_runs.coffee
+++ b/src/js/data/fake_runs.coffee
@@ -1,21 +1,8 @@
 _ = require 'lodash'
 
-words = _.words """
-flesh cobweb groan blush acceptable friendly jar spotless colorful vessel ask
-harm ripe rain concentrate educated perform hellish irate escape unlock float
-swing level ultra camera increase mark secret ladybug retire motion smile room
-craven lumpy rain uneven group hurt rigid tongue alcoholic plot sneeze black creepy point wise
-clean knee attend chess vagabond deeply flock eatable bitter pump popcorn attraction careless
-jealous prefer juggle right slope cause damp stupid desire babies wash rat crook
-bake baby available coordinated superb refuse connect cellar flowery first handsomely
-shallow giraffe ordinary peep deadpan welcome fang store explain
-"""
+randomText = require './random_text.coffee'
 
-randomText = (prefix="", max=300, min=4)->
-  length = _.random(min,max)
-  "#{prefix} #{_.sample(words, length).join '' }"
-
-answers = _.times(4, (i) -> randomText("choice #{i}:", 100))
+answers = _.times(4, (i) -> randomText("choice #{i} – ", 10))
 
 randomAnswer =
   1: -> _.sample(answers)
@@ -37,20 +24,21 @@ getSubmissions = (questions) ->
     answers: getAnswers(questions)
 
 getAnswers = (questions) ->
-  answers = []
+  results = []
   for question, idx in questions
     feedbackType = if idx % 2 == 0 then "Embeddable::FeedbackItem" else "CRater::FeedbackItem"
     maxScore = if idx is 1 then 6 else if idx is 3 then 4 else 0
+    answerText =  randomAnswer[idx+1]()
     answer = {
       question_index: question.index
-      answer: randomAnswer[_.random(1, 4)]()
+      answer: answerText
       feedback: "feedback text from c-rater here"
       feedback_type: feedbackType
       score: _.random maxScore
       max_score: maxScore
     }
-    answers.push answer
-  answers
+    results.push answer
+  results
 
 module.exports = (students, questions, sequence) ->
 

--- a/src/js/data/random_text.coffee
+++ b/src/js/data/random_text.coffee
@@ -1,0 +1,16 @@
+_ = require 'lodash'
+
+words = _.words """
+Still, despite the anatomical points that mark them as a different species, dire wolves probably lived much
+like the gray wolves that still trod parts of North America. The sheer number of remains found at the La Brea asphalt
+seeps, outnumbering any other large vertebrate by far, only make sense if dire wolves were pack hunters, which falls
+into accord with evidence that these carnivores were chasing mid-sized herbivores such as horses. Wolves lack the
+grappling abilities of cats, relying instead on their running endurance and jaws, and so the dire wolf has almost
+always been envisioned as roving through prehistoric habitats in packs. More than that, some dire wolf remains at
+La Brea show painful injuries that would have crippled the animals and yet show signs of healing. This hints that
+these dogs had some sort of social support structure that allowed them to survive.
+"""
+
+module.exports = (prefix="", max=300, min=4) ->
+  length = _.random(min,max)
+  "#{prefix} #{_.sample(words, length).join ' ' }"


### PR DESCRIPTION
Mostly CSS changes to handle students with long names, and pages with long titles.   

Also:
- moved the fake data random words into its own file so it could be used to create random page names in fake data.
- Fix a bug with fake data where MC answers weren't being created correctly

@pjanik if you have a chance.
