### PR TITLE
extract `UrlHelper` so we can switch to new /api/v1/ dashboard routes.

### DIFF
--- a/src/js/components/app.coffee
+++ b/src/js/components/app.coffee
@@ -13,6 +13,7 @@ sequenceFakeData  = require '../data/fake_sequence.coffee'
 runsFakeData      = require '../data/fake_runs.coffee'
 dataHelpers       = require '../data/helpers.coffee'
 utils             = require '../utils.coffee'
+UrlHelper         = require '../data/urls.coffee'
 
 ShowingOverview        = "ShowingOverview"
 ShowingStudentDetails  = "ShowingStudentDetails"
@@ -47,6 +48,7 @@ App = React.createClass
     # Note that you can replace data/offering.coffee content to point to real LARA instance.
     params = utils.urlParams()
     @setOffering(params.offering)
+    @urlHelper = new UrlHelper()
 
     # Refresh report.
 
@@ -111,7 +113,7 @@ App = React.createClass
       if @state.sequenceId
         resources = "sequences"
         id = @state.sequenceId
-      url = "#{@state.laraBaseUrl}/#{resources}/#{id}/dashboard_toc"
+      url = @urlHelper.tocUrl(@state.laraBaseUrl, resources, id)
       $.ajax
         url: url
         dataType: "jsonp"
@@ -148,7 +150,7 @@ App = React.createClass
         handleRunsData(runsFakeData(@state.studentsPortalInfo, @getQuestions(), @state.sequence))
     else
       $.ajax
-        url: "#{@state.laraBaseUrl}/runs/dashboard"
+        url: @urlHelper.dashRunsUrl(@state.laraBaseUrl)
         data:
           page_id: pageId,
           endpoint_urls: dataHelpers.getEndpointUrls(@state.studentsPortalInfo)

--- a/src/js/data/urls.coffee
+++ b/src/js/data/urls.coffee
@@ -1,0 +1,18 @@
+configs =
+  0:
+    tocUrl: (base, resources, id) -> "#{base}/#{resources}/#{id}/dashboard_toc"
+    dashRunsUrl: (base) -> "#{base}/runs/dashboard"
+  1:
+    tocUrl: (base, resources, id) -> "#{base}/api/v1/dashboard_toc/#{resources}/#{id}"
+    dashRunsUrl: (base) -> "#{base}/api/v1/dashboard_runs"
+
+class UrlHelper
+  constructor: (@version=0) ->
+
+  tocUrl: (base, resources, id) ->
+    configs[@version].tocUrl(base,resources,id)
+
+  dashRunsUrl: (base) ->
+    configs[@version].dashRunsUrl(base)
+
+module.exports = UrlHelper


### PR DESCRIPTION
When LARA `6971e91`  is deployed, we can start using new routes to the dashboard service.

This is an incremental improvement to centralize the information about where to look for dashboard endpoints.  

[#121491615]

https://www.pivotaltracker.com/story/show/121491615
